### PR TITLE
Change shebang to /usr/bin/env python3

### DIFF
--- a/viralverify.py
+++ b/viralverify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os, errno
 import sys
 import argparse


### PR DESCRIPTION
Please consider changing the shebang of the script to `#!/usr/bin/env python3`. That way the script does not necessarily use the system-wide python installation and can be used with for instance [conda](https://docs.conda.io/en/latest/) environments. This is especially useful for users working on their employer's server or high-performance computing (HPC) cluster where they don't have administrative (root) privileges.

Personally, I have been using the below YAML file to generate an environment suitable for running viralVerify, but I found it would return ImportErrors (cannot find package 'Bio'). With this new shebang, it works fine.

```yaml
name: viralverify

channels:
- defaults
- bioconda
- conda-forge

dependencies:
- python>=3.6
- prodigal=2.6.3
- hmmer=3.3.2
- blast=2.11.0
- biopython=1.78
```